### PR TITLE
Move response handler to request options

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 		"php": "^7.4 | ^8.0",
         "php-http/guzzle7-adapter": "^1.0",
         "php-http/httplug": "^2.2",
-		"microsoft/kiota-abstractions": "dev-feat/response-handler-option",
+		"microsoft/kiota-abstractions": "0.5.0",
 		"ext-zlib": "*",
 		"ext-json": "*"
 	},

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 		"php": "^7.4 | ^8.0",
         "php-http/guzzle7-adapter": "^1.0",
         "php-http/httplug": "^2.2",
-		"microsoft/kiota-abstractions": "^0.4.0",
+		"microsoft/kiota-abstractions": "dev-feat/response-handler-option",
 		"ext-zlib": "*",
 		"ext-json": "*"
 	},

--- a/src/GuzzleRequestAdapter.php
+++ b/src/GuzzleRequestAdapter.php
@@ -13,6 +13,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Request;
 use Http\Promise\FulfilledPromise;
 use Http\Promise\Promise;
+use League\Uri\Contracts\UriException;
 use Microsoft\Kiota\Abstractions\ApiClientBuilder;
 use Microsoft\Kiota\Abstractions\ApiException;
 use Microsoft\Kiota\Abstractions\Authentication\AuthenticationProvider;
@@ -28,6 +29,7 @@ use Microsoft\Kiota\Abstractions\Store\BackingStoreFactory;
 use Microsoft\Kiota\Abstractions\Store\BackingStoreFactorySingleton;
 use Microsoft\Kiota\Abstractions\Types\Date;
 use Microsoft\Kiota\Abstractions\Types\Time;
+use Microsoft\Kiota\Http\Middleware\Options\ResponseHandlerOption;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
@@ -83,20 +85,21 @@ class GuzzleRequestAdapter implements RequestAdapter
     /**
      * @inheritDoc
      */
-    public function sendAsync(RequestInformation $requestInfo, array $targetCallable, ?ResponseHandler $responseHandler = null, ?array $errorMappings = null): Promise
+    public function sendAsync(RequestInformation $requestInfo, array $targetCallable, ?array $errorMappings = null): Promise
     {
         return $this->getHttpResponseMessage($requestInfo)->then(
-            function (ResponseInterface $result) use ($targetCallable, $responseHandler, $errorMappings) {
+            function (ResponseInterface $result) use ($targetCallable, $requestInfo, $errorMappings) {
                 $this->throwFailedResponse($result, $errorMappings);
 
                 if ($this->is204NoContentResponse($result)) {
                     return null;
                 }
-                if (!$responseHandler) {
-                    $rootNode = $this->getRootParseNode($result);
-                    return $rootNode->getObjectValue($targetCallable);
+                $responseHandlerOption = $requestInfo->getRequestOptions()[ResponseHandlerOption::class] ?? null;
+                if ($responseHandlerOption && is_a($responseHandlerOption, ResponseHandlerOption::class)) {
+                    return $responseHandlerOption->getResponseHandler()->handleResponseAsync($result);
                 }
-                return $responseHandler->handleResponseAsync($result);
+                $rootNode = $this->getRootParseNode($result);
+                return $rootNode->getObjectValue($targetCallable);
             }
         );
     }
@@ -120,19 +123,20 @@ class GuzzleRequestAdapter implements RequestAdapter
     /**
      * @inheritDoc
      */
-    public function sendCollectionAsync(RequestInformation $requestInfo, array $targetCallable, ?ResponseHandler $responseHandler = null, ?array $errorMappings = null): Promise
+    public function sendCollectionAsync(RequestInformation $requestInfo, array $targetCallable, ?array $errorMappings = null): Promise
     {
         return $this->getHttpResponseMessage($requestInfo)->then(
-            function (ResponseInterface $result) use ($targetCallable, $responseHandler, $errorMappings) {
+            function (ResponseInterface $result) use ($targetCallable, $requestInfo, $errorMappings) {
                 $this->throwFailedResponse($result, $errorMappings);
 
                 if ($this->is204NoContentResponse($result)) {
                     return new FulfilledPromise(null);
                 }
-                if (!$responseHandler) {
-                    return $this->getRootParseNode($result)->getCollectionOfObjectValues($targetCallable);
+                $responseHandlerOption = $requestInfo->getRequestOptions()[ResponseHandlerOption::class] ?? null;
+                if ($responseHandlerOption && is_a($responseHandlerOption, ResponseHandlerOption::class)) {
+                    return $responseHandlerOption->getResponseHandler()->handleResponseAsync($result);
                 }
-                return $responseHandler->handleResponseAsync($result);
+                return $this->getRootParseNode($result)->getCollectionOfObjectValues($targetCallable);
             }
         );
     }
@@ -140,43 +144,44 @@ class GuzzleRequestAdapter implements RequestAdapter
     /**
      * @inheritDoc
      */
-    public function sendPrimitiveAsync(RequestInformation $requestInfo, string $primitiveType, ?ResponseHandler $responseHandler = null, ?array $errorMappings = null): Promise
+    public function sendPrimitiveAsync(RequestInformation $requestInfo, string $primitiveType, ?array $errorMappings = null): Promise
     {
         return $this->getHttpResponseMessage($requestInfo)->then(
-            function (ResponseInterface $result) use ($primitiveType, $responseHandler, $errorMappings) {
+            function (ResponseInterface $result) use ($primitiveType, $requestInfo, $errorMappings) {
                 $this->throwFailedResponse($result, $errorMappings);
 
                 if ($this->is204NoContentResponse($result)) {
                     return null;
                 }
-                if (!$responseHandler) {
-                    if ($primitiveType === StreamInterface::class) {
-                        return $result->getBody();
-                    }
-                    $rootParseNode = $this->getRootParseNode($result);
-                    switch ($primitiveType) {
-                        case 'int':
-                        case 'long':
-                            return $rootParseNode->getIntegerValue();
-                        case 'float':
-                            return $rootParseNode->getFloatValue();
-                        case 'bool':
-                            return $rootParseNode->getBooleanValue();
-                        case 'string':
-                            return $rootParseNode->getStringValue();
-                        case \DateTime::class:
-                            return $rootParseNode->getDateTimeValue();
-                        case \DateInterval::class:
-                            return $rootParseNode->getDateIntervalValue();
-                        case Date::class:
-                            return $rootParseNode->getDateValue();
-                        case Time::class:
-                            return $rootParseNode->getTimeValue();
-                        default:
-                            throw new \InvalidArgumentException("Unsupported primitive type $primitiveType");
-                    }
+                if ($primitiveType === StreamInterface::class) {
+                    return $result->getBody();
                 }
-                return $responseHandler->handleResponseAsync($result);
+                $responseHandlerOption = $requestInfo->getRequestOptions()[ResponseHandlerOption::class] ?? null;
+                if ($responseHandlerOption && is_a($responseHandlerOption, ResponseHandlerOption::class)) {
+                    return $responseHandlerOption->getResponseHandler()->handleResponseAsync($result);
+                }
+                $rootParseNode = $this->getRootParseNode($result);
+                switch ($primitiveType) {
+                    case 'int':
+                    case 'long':
+                        return $rootParseNode->getIntegerValue();
+                    case 'float':
+                        return $rootParseNode->getFloatValue();
+                    case 'bool':
+                        return $rootParseNode->getBooleanValue();
+                    case 'string':
+                        return $rootParseNode->getStringValue();
+                    case \DateTime::class:
+                        return $rootParseNode->getDateTimeValue();
+                    case \DateInterval::class:
+                        return $rootParseNode->getDateIntervalValue();
+                    case Date::class:
+                        return $rootParseNode->getDateValue();
+                    case Time::class:
+                        return $rootParseNode->getTimeValue();
+                    default:
+                        throw new \InvalidArgumentException("Unsupported primitive type $primitiveType");
+                }
             }
         );
     }
@@ -184,19 +189,20 @@ class GuzzleRequestAdapter implements RequestAdapter
     /**
      * @inheritDoc
      */
-    public function sendPrimitiveCollectionAsync(RequestInformation $requestInfo, string $primitiveType, ?ResponseHandler $responseHandler = null, ?array $errorMappings = null): Promise
+    public function sendPrimitiveCollectionAsync(RequestInformation $requestInfo, string $primitiveType, ?array $errorMappings = null): Promise
     {
         return $this->getHttpResponseMessage($requestInfo)->then(
-            function (ResponseInterface $result) use ($primitiveType, $responseHandler, $errorMappings) {
+            function (ResponseInterface $result) use ($primitiveType, $requestInfo, $errorMappings) {
                 $this->throwFailedResponse($result, $errorMappings);
 
                 if ($this->is204NoContentResponse($result)) {
                     return null;
                 }
-                if (!$responseHandler) {
-                    return $this->getRootParseNode($result)->getCollectionOfPrimitiveValues($primitiveType);
+                $responseHandlerOption = $requestInfo->getRequestOptions()[ResponseHandlerOption::class] ?? null;
+                if ($responseHandlerOption && is_a($responseHandlerOption, ResponseHandlerOption::class)) {
+                    return $responseHandlerOption->getResponseHandler()->handleResponseAsync($result);
                 }
-                return $responseHandler->handleResponseAsync($result);
+                return $this->getRootParseNode($result)->getCollectionOfPrimitiveValues($primitiveType);
             }
         );
     }
@@ -204,13 +210,14 @@ class GuzzleRequestAdapter implements RequestAdapter
     /**
      * @inheritDoc
      */
-    public function sendNoContentAsync(RequestInformation $requestInfo, ?ResponseHandler $responseHandler = null, ?array $errorMappings = null): Promise
+    public function sendNoContentAsync(RequestInformation $requestInfo, ?array $errorMappings = null): Promise
     {
         return $this->getHttpResponseMessage($requestInfo)->then(
-            function (ResponseInterface $result) use ($responseHandler, $errorMappings) {
+            function (ResponseInterface $result) use ($requestInfo, $errorMappings) {
                 $this->throwFailedResponse($result, $errorMappings);
-                if ($responseHandler) {
-                    return $responseHandler->handleResponseAsync($result);
+                $responseHandlerOption = $requestInfo->getRequestOptions()[ResponseHandlerOption::class] ?? null;
+                if ($responseHandlerOption && is_a($responseHandlerOption, ResponseHandlerOption::class)) {
+                    return $responseHandlerOption->getResponseHandler()->handleResponseAsync($result);
                 }
                 return null;
             }
@@ -248,6 +255,7 @@ class GuzzleRequestAdapter implements RequestAdapter
      *
      * @param RequestInformation $requestInformation
      * @return RequestInterface
+     * @throws UriException
      */
     public function getPsrRequestFromRequestInformation(RequestInformation $requestInformation): RequestInterface
     {

--- a/src/GuzzleRequestAdapter.php
+++ b/src/GuzzleRequestAdapter.php
@@ -258,7 +258,7 @@ class GuzzleRequestAdapter implements RequestAdapter
         return new Request(
             $requestInformation->httpMethod,
             $requestInformation->getUri(),
-            $requestInformation->headers,
+            $requestInformation->getHeaders()->getAll(),
             $requestInformation->content
         );
     }

--- a/src/GuzzleRequestAdapter.php
+++ b/src/GuzzleRequestAdapter.php
@@ -19,7 +19,6 @@ use Microsoft\Kiota\Abstractions\ApiException;
 use Microsoft\Kiota\Abstractions\Authentication\AuthenticationProvider;
 use Microsoft\Kiota\Abstractions\RequestAdapter;
 use Microsoft\Kiota\Abstractions\RequestInformation;
-use Microsoft\Kiota\Abstractions\ResponseHandler;
 use Microsoft\Kiota\Abstractions\Serialization\ParseNode;
 use Microsoft\Kiota\Abstractions\Serialization\ParseNodeFactory;
 use Microsoft\Kiota\Abstractions\Serialization\ParseNodeFactoryRegistry;
@@ -89,14 +88,13 @@ class GuzzleRequestAdapter implements RequestAdapter
     {
         return $this->getHttpResponseMessage($requestInfo)->then(
             function (ResponseInterface $result) use ($targetCallable, $requestInfo, $errorMappings) {
-                $this->throwFailedResponse($result, $errorMappings);
-
-                if ($this->is204NoContentResponse($result)) {
-                    return null;
-                }
                 $responseHandlerOption = $requestInfo->getRequestOptions()[ResponseHandlerOption::class] ?? null;
                 if ($responseHandlerOption && is_a($responseHandlerOption, ResponseHandlerOption::class)) {
-                    return $responseHandlerOption->getResponseHandler()->handleResponseAsync($result);
+                    return $responseHandlerOption->getResponseHandler()->handleResponseAsync($result, $errorMappings);
+                }
+                $this->throwFailedResponse($result, $errorMappings);
+                if ($this->is204NoContentResponse($result)) {
+                    return null;
                 }
                 $rootNode = $this->getRootParseNode($result);
                 return $rootNode->getObjectValue($targetCallable);
@@ -127,14 +125,13 @@ class GuzzleRequestAdapter implements RequestAdapter
     {
         return $this->getHttpResponseMessage($requestInfo)->then(
             function (ResponseInterface $result) use ($targetCallable, $requestInfo, $errorMappings) {
-                $this->throwFailedResponse($result, $errorMappings);
-
-                if ($this->is204NoContentResponse($result)) {
-                    return new FulfilledPromise(null);
-                }
                 $responseHandlerOption = $requestInfo->getRequestOptions()[ResponseHandlerOption::class] ?? null;
                 if ($responseHandlerOption && is_a($responseHandlerOption, ResponseHandlerOption::class)) {
-                    return $responseHandlerOption->getResponseHandler()->handleResponseAsync($result);
+                    return $responseHandlerOption->getResponseHandler()->handleResponseAsync($result, $errorMappings);
+                }
+                $this->throwFailedResponse($result, $errorMappings);
+                if ($this->is204NoContentResponse($result)) {
+                    return new FulfilledPromise(null);
                 }
                 return $this->getRootParseNode($result)->getCollectionOfObjectValues($targetCallable);
             }
@@ -148,17 +145,16 @@ class GuzzleRequestAdapter implements RequestAdapter
     {
         return $this->getHttpResponseMessage($requestInfo)->then(
             function (ResponseInterface $result) use ($primitiveType, $requestInfo, $errorMappings) {
+                $responseHandlerOption = $requestInfo->getRequestOptions()[ResponseHandlerOption::class] ?? null;
+                if ($responseHandlerOption && is_a($responseHandlerOption, ResponseHandlerOption::class)) {
+                    return $responseHandlerOption->getResponseHandler()->handleResponseAsync($result, $errorMappings);
+                }
                 $this->throwFailedResponse($result, $errorMappings);
-
                 if ($this->is204NoContentResponse($result)) {
                     return null;
                 }
                 if ($primitiveType === StreamInterface::class) {
                     return $result->getBody();
-                }
-                $responseHandlerOption = $requestInfo->getRequestOptions()[ResponseHandlerOption::class] ?? null;
-                if ($responseHandlerOption && is_a($responseHandlerOption, ResponseHandlerOption::class)) {
-                    return $responseHandlerOption->getResponseHandler()->handleResponseAsync($result);
                 }
                 $rootParseNode = $this->getRootParseNode($result);
                 switch ($primitiveType) {
@@ -193,14 +189,13 @@ class GuzzleRequestAdapter implements RequestAdapter
     {
         return $this->getHttpResponseMessage($requestInfo)->then(
             function (ResponseInterface $result) use ($primitiveType, $requestInfo, $errorMappings) {
-                $this->throwFailedResponse($result, $errorMappings);
-
-                if ($this->is204NoContentResponse($result)) {
-                    return null;
-                }
                 $responseHandlerOption = $requestInfo->getRequestOptions()[ResponseHandlerOption::class] ?? null;
                 if ($responseHandlerOption && is_a($responseHandlerOption, ResponseHandlerOption::class)) {
-                    return $responseHandlerOption->getResponseHandler()->handleResponseAsync($result);
+                    return $responseHandlerOption->getResponseHandler()->handleResponseAsync($result, $errorMappings);
+                }
+                $this->throwFailedResponse($result, $errorMappings);
+                if ($this->is204NoContentResponse($result)) {
+                    return null;
                 }
                 return $this->getRootParseNode($result)->getCollectionOfPrimitiveValues($primitiveType);
             }
@@ -214,11 +209,11 @@ class GuzzleRequestAdapter implements RequestAdapter
     {
         return $this->getHttpResponseMessage($requestInfo)->then(
             function (ResponseInterface $result) use ($requestInfo, $errorMappings) {
-                $this->throwFailedResponse($result, $errorMappings);
                 $responseHandlerOption = $requestInfo->getRequestOptions()[ResponseHandlerOption::class] ?? null;
                 if ($responseHandlerOption && is_a($responseHandlerOption, ResponseHandlerOption::class)) {
-                    return $responseHandlerOption->getResponseHandler()->handleResponseAsync($result);
+                    return $responseHandlerOption->getResponseHandler()->handleResponseAsync($result, $errorMappings);
                 }
+                $this->throwFailedResponse($result, $errorMappings);
                 return null;
             }
         );

--- a/src/Middleware/Options/ResponseHandlerOption.php
+++ b/src/Middleware/Options/ResponseHandlerOption.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Copyright (c) Microsoft Corporation.  All Rights Reserved.
+ * Licensed under the MIT License.  See License in the project root
+ * for license information.
+ */
+
+
+namespace Microsoft\Kiota\Http\Middleware\Options;
+
+
+use Microsoft\Kiota\Abstractions\RequestOption;
+use Microsoft\Kiota\Abstractions\ResponseHandler;
+
+/**
+ * Class ResponseHandlerOption
+ *
+ * Configure a custom response handler for the request
+ *
+ * @package Microsoft\Kiota\Http\Middleware\Options
+ * @copyright 2023 Microsoft Corporation
+ * @license https://opensource.org/licenses/MIT MIT License
+ */
+class ResponseHandlerOption implements RequestOption
+{
+    /**
+     * @var ResponseHandler|null
+     */
+    private ?ResponseHandler $responseHandler = null;
+
+    /**
+     * @param ResponseHandler|null $responseHandler custom response handler
+     */
+    public function __construct(?ResponseHandler $responseHandler = null)
+    {
+        $this->responseHandler = $responseHandler;
+    }
+
+    /**
+     * @return ResponseHandler|null
+     */
+    public function getResponseHandler(): ?ResponseHandler
+    {
+        return $this->responseHandler;
+    }
+}

--- a/tests/GuzzleRequestAdapterTest.php
+++ b/tests/GuzzleRequestAdapterTest.php
@@ -17,6 +17,7 @@ use Microsoft\Kiota\Abstractions\Serialization\ParseNodeFactory;
 use Microsoft\Kiota\Abstractions\Serialization\SerializationWriter;
 use Microsoft\Kiota\Abstractions\Serialization\SerializationWriterFactory;
 use Microsoft\Kiota\Http\GuzzleRequestAdapter;
+use Microsoft\Kiota\Http\Middleware\Options\ResponseHandlerOption;
 use PHPUnit\Framework\TestCase;
 
 class GuzzleRequestAdapterTest extends TestCase
@@ -106,7 +107,8 @@ class GuzzleRequestAdapterTest extends TestCase
         $customResponseHandler = $this->createMock(ResponseHandler::class);
         $customResponseHandler->expects($this->once())
             ->method('handleResponseAsync');
-        $requestAdapter->sendAsync($this->requestInformation, array(TestUser::class, 'createFromDiscriminatorValue'), $customResponseHandler);
+        $this->requestInformation->addRequestOptions(new ResponseHandlerOption($customResponseHandler));
+        $requestAdapter->sendAsync($this->requestInformation, array(TestUser::class, 'createFromDiscriminatorValue'));
     }
 
     public function testSendCollectionAsync(): void
@@ -125,7 +127,8 @@ class GuzzleRequestAdapterTest extends TestCase
         $customResponseHandler = $this->createMock(ResponseHandler::class);
         $customResponseHandler->expects($this->once())
             ->method('handleResponseAsync');
-        $requestAdapter->sendCollectionAsync($this->requestInformation, array(TestUser::class, 'createFromDiscriminatorValue'), $customResponseHandler);
+        $this->requestInformation->addRequestOptions(new ResponseHandlerOption($customResponseHandler));
+        $requestAdapter->sendCollectionAsync($this->requestInformation, array(TestUser::class, 'createFromDiscriminatorValue'));
     }
 
     public function testSendPrimitiveAsync(): void
@@ -149,7 +152,8 @@ class GuzzleRequestAdapterTest extends TestCase
         $customResponseHandler = $this->createMock(ResponseHandler::class);
         $customResponseHandler->expects($this->once())
             ->method('handleResponseAsync');
-        $requestAdapter->sendPrimitiveAsync($this->requestInformation, 'int', $customResponseHandler);
+        $this->requestInformation->addRequestOptions(new ResponseHandlerOption($customResponseHandler));
+        $requestAdapter->sendPrimitiveAsync($this->requestInformation, 'int');
     }
 
     public function testSendPrimitiveCollectionAsync(): void
@@ -168,7 +172,8 @@ class GuzzleRequestAdapterTest extends TestCase
         $customResponseHandler = $this->createMock(ResponseHandler::class);
         $customResponseHandler->expects($this->once())
             ->method('handleResponseAsync');
-        $requestAdapter->sendPrimitiveCollectionAsync($this->requestInformation, 'string', $customResponseHandler);
+        $this->requestInformation->addRequestOptions(new ResponseHandlerOption($customResponseHandler));
+        $requestAdapter->sendPrimitiveCollectionAsync($this->requestInformation, 'string');
     }
 
     public function testSendNoContentAsync(): void
@@ -184,7 +189,8 @@ class GuzzleRequestAdapterTest extends TestCase
         $customResponseHandler = $this->createMock(ResponseHandler::class);
         $customResponseHandler->expects($this->once())
             ->method('handleResponseAsync');
-        $requestAdapter->sendNoContentAsync($this->requestInformation,  $customResponseHandler);
+        $this->requestInformation->addRequestOptions(new ResponseHandlerOption($customResponseHandler));
+        $requestAdapter->sendNoContentAsync($this->requestInformation);
     }
 
     public function testExceptionThrownOnErrorResponses(): void

--- a/tests/GuzzleRequestAdapterTest.php
+++ b/tests/GuzzleRequestAdapterTest.php
@@ -33,9 +33,9 @@ class GuzzleRequestAdapterTest extends TestCase
     {
         $this->requestInformation = new RequestInformation();
         $this->requestInformation->httpMethod = 'GET';
-        $this->requestInformation->headers = [
+        $this->requestInformation->addHeaders([
             'RequestId' => '1'
-        ];
+        ]);
         $this->requestInformation->content = Utils::streamFor('body');
         $this->requestInformation->setUri($this->baseUrl);
 
@@ -89,7 +89,7 @@ class GuzzleRequestAdapterTest extends TestCase
     {
         $psrRequest = $this->mockRequestAdapter()->getPsrRequestFromRequestInformation($this->requestInformation);
         $this->assertEquals($this->requestInformation->httpMethod, $psrRequest->getMethod());
-        $this->assertEquals($this->requestInformation->headers['RequestId'], $psrRequest->getHeaderLine('RequestId'));
+        $this->assertEquals($this->requestInformation->getHeaders()->get('RequestId')[0], $psrRequest->getHeaderLine('RequestId'));
         $this->assertEquals('body', $psrRequest->getBody()->getContents());
         $this->assertEquals($this->requestInformation->getUri(), (string)$psrRequest->getUri());
     }


### PR DESCRIPTION
part of https://github.com/microsoft/kiota/issues/1856

This PR:
- Removes response handler parameter from request adapter to align with abstractions changes in https://github.com/microsoft/kiota-abstractions-php/pull/27
- Passes error mappings to user-defined response handlers
- Bumps abstractions