### PR TITLE
Fix bug in calculating chaos percentage

### DIFF
--- a/src/Middleware/ChaosHandler.php
+++ b/src/Middleware/ChaosHandler.php
@@ -61,8 +61,8 @@ class ChaosHandler
             $this->chaosOption = $options[ChaosOption::class];
         }
 
-        $randomPercentage = rand(0, ChaosOption::MAX_CHAOS_PERCENTAGE);
-        if ($randomPercentage < $this->chaosOption->getChaosPercentage()) {
+        $randomPercentage = rand(1, ChaosOption::MAX_CHAOS_PERCENTAGE);
+        if ($randomPercentage <= $this->chaosOption->getChaosPercentage()) {
             $response = $this->randomChaosResponse($request, $options);
             if ($response) {
                 return Create::promiseFor($response);


### PR DESCRIPTION
Chaos handler should randomly determine a chaos percentage between 1 & 100 and check if the generated number is within the failure threshhold specified in the ChaosOptions object.

This PR fixes a bug where if the chaos threshhold was 10% and the Chaos handler randomly generated 10, a chaos response would not be returned. Instead, the request would proceed down the middleware chain to the desired destination server.