### PR TITLE
Retry failed responses with CAE challenge once

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 		"php": "^7.4 | ^8.0",
         "php-http/guzzle7-adapter": "^1.0",
         "php-http/httplug": "^2.2",
-		"microsoft/kiota-abstractions": "^0.6.0",
+		"microsoft/kiota-abstractions": "dev-feat/cae-support",
 		"ext-zlib": "*",
 		"ext-json": "*"
 	},

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 		"php": "^7.4 | ^8.0",
         "php-http/guzzle7-adapter": "^1.0",
         "php-http/httplug": "^2.2",
-		"microsoft/kiota-abstractions": "dev-feat/cae-support",
+		"microsoft/kiota-abstractions": "^0.6.0",
 		"ext-zlib": "*",
 		"ext-json": "*"
 	},

--- a/src/GuzzleRequestAdapter.php
+++ b/src/GuzzleRequestAdapter.php
@@ -375,7 +375,6 @@ class GuzzleRequestAdapter implements RequestAdapter
             $claims = $matches[1];
             /** @var ResponseInterface $response */
             $response =  $this->getHttpResponseMessage($request, $claims)->wait();
-            return $response;
         }
         return $response;
     }


### PR DESCRIPTION
Extracts claims from the `WWW-Authenticate` header found in the response and retries to authenticate the request & send it again to the API

depends on https://github.com/microsoft/kiota-abstractions-php/pull/51
part of https://github.com/microsoft/kiota/issues/1590