### PR TITLE
Add middleware tests and re-order handler stack

### DIFF
--- a/src/KiotaClientFactory.php
+++ b/src/KiotaClientFactory.php
@@ -14,6 +14,9 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware as GuzzleMiddleware;
 use GuzzleHttp\Utils;
 use Microsoft\Kiota\Http\Middleware\KiotaMiddleware;
+use Microsoft\Kiota\Http\Middleware\ParametersNameDecodingHandler;
+use Microsoft\Kiota\Http\Middleware\RetryHandler;
+use Microsoft\Kiota\Http\Middleware\UserAgentHandler;
 
 /**
  * Class KiotaClientFactory
@@ -67,10 +70,10 @@ class KiotaClientFactory
     public static function getDefaultHandlerStack(): HandlerStack
     {
         $handlerStack = new HandlerStack(Utils::chooseHandler());
-        $handlerStack->push(KiotaMiddleware::parameterNamesDecoding());
-        $handlerStack->push(GuzzleMiddleware::redirect());
-        $handlerStack->push(KiotaMiddleware::userAgent());
-        $handlerStack->push(KiotaMiddleware::retry());
+        $handlerStack->push(KiotaMiddleware::parameterNamesDecoding(), ParametersNameDecodingHandler::HANDLER_NAME);
+        $handlerStack->push(GuzzleMiddleware::redirect(), 'kiotaRedirectHandler');
+        $handlerStack->push(KiotaMiddleware::userAgent(), UserAgentHandler::HANDLER_NAME);
+        $handlerStack->push(KiotaMiddleware::retry(), RetryHandler::HANDLER_NAME);
         return $handlerStack;
     }
 }

--- a/src/KiotaClientFactory.php
+++ b/src/KiotaClientFactory.php
@@ -68,9 +68,9 @@ class KiotaClientFactory
     {
         $handlerStack = new HandlerStack(Utils::chooseHandler());
         $handlerStack->push(KiotaMiddleware::parameterNamesDecoding());
-        $handlerStack->push(KiotaMiddleware::retry());
-        $handlerStack->push(KiotaMiddleware::userAgent());
         $handlerStack->push(GuzzleMiddleware::redirect());
+        $handlerStack->push(KiotaMiddleware::userAgent());
+        $handlerStack->push(KiotaMiddleware::retry());
         return $handlerStack;
     }
 }

--- a/src/Middleware/ChaosHandler.php
+++ b/src/Middleware/ChaosHandler.php
@@ -28,6 +28,7 @@ use Psr\Http\Message\ResponseInterface;
  */
 class ChaosHandler
 {
+    public const HANDLER_NAME = 'kiotaChaosHandler';
     /**
      * @var callable Next handler in the middleware pipeline
      */

--- a/src/Middleware/CompressionHandler.php
+++ b/src/Middleware/CompressionHandler.php
@@ -28,6 +28,7 @@ use Psr\Http\Message\ResponseInterface;
  */
 class CompressionHandler
 {
+    public const HANDLER_NAME = 'kiotaCompressionHandler';
     private const COMPRESSION_RETRY_ATTEMPT = 'compressionRetryAttempt';
 
     /**

--- a/src/Middleware/Options/UserAgentHandlerOption.php
+++ b/src/Middleware/Options/UserAgentHandlerOption.php
@@ -112,8 +112,9 @@ class UserAgentHandlerOption implements RequestOption
     {
         return function (RequestInterface $request) {
             $currentUserAgentHeaderValue = $request->getHeaderLine(UserAgentHandler::USER_AGENT_HEADER_NAME);
-            if ($currentUserAgentHeaderValue)
+            if ($currentUserAgentHeaderValue) {
                 $currentUserAgentHeaderValue .= " ";
+            }
             $currentUserAgentHeaderValue .= $this->getUserAgentHeaderValue();
             return $request->withHeader(UserAgentHandler::USER_AGENT_HEADER_NAME, $currentUserAgentHeaderValue);
         };

--- a/src/Middleware/Options/UserAgentHandlerOption.php
+++ b/src/Middleware/Options/UserAgentHandlerOption.php
@@ -111,8 +111,10 @@ class UserAgentHandlerOption implements RequestOption
     public function initUserAgentConfigurator(): callable
     {
         return function (RequestInterface $request) {
-            $currentUserAgentHeaderValue = $request->getHeader(UserAgentHandler::USER_AGENT_HEADER_NAME);
-            $currentUserAgentHeaderValue []= $this->getUserAgentHeaderValue();
+            $currentUserAgentHeaderValue = $request->getHeaderLine(UserAgentHandler::USER_AGENT_HEADER_NAME);
+            if ($currentUserAgentHeaderValue)
+                $currentUserAgentHeaderValue .= " ";
+            $currentUserAgentHeaderValue .= $this->getUserAgentHeaderValue();
             return $request->withHeader(UserAgentHandler::USER_AGENT_HEADER_NAME, $currentUserAgentHeaderValue);
         };
     }

--- a/src/Middleware/ParametersNameDecodingHandler.php
+++ b/src/Middleware/ParametersNameDecodingHandler.php
@@ -28,6 +28,10 @@ use Psr\Http\Message\RequestInterface;
 class ParametersNameDecodingHandler
 {
     /**
+     * Handler name to reference within the handler stack
+     */
+    public const HANDLER_NAME = "kiotaParameterNamesDecodingHandler";
+    /**
      * @var ParametersDecodingOption configuration for the middleware
      */
     private ParametersDecodingOption $decodingOption;

--- a/src/Middleware/RetryHandler.php
+++ b/src/Middleware/RetryHandler.php
@@ -31,6 +31,7 @@ use function pow;
  */
 class RetryHandler
 {
+    public const HANDLER_NAME = 'kiotaRetryHandler';
     private const RETRY_AFTER_HEADER = "Retry-After";
     private const RETRY_ATTEMPT_HEADER = "Retry-Attempt";
 

--- a/src/Middleware/UserAgentHandler.php
+++ b/src/Middleware/UserAgentHandler.php
@@ -12,6 +12,7 @@ use Psr\Http\Message\RequestInterface;
  */
 class UserAgentHandler
 {
+    public const HANDLER_NAME = 'kiotaUserAgentHandler';
     public const USER_AGENT_HEADER_NAME = 'User-Agent';
 
     private UserAgentHandlerOption $userAgentHandlerOption;

--- a/tests/KiotaClientFactoryTest.php
+++ b/tests/KiotaClientFactoryTest.php
@@ -2,9 +2,15 @@
 
 namespace Microsoft\Kiota\Http\Test;
 
+use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Microsoft\Kiota\Http\Constants;
 use Microsoft\Kiota\Http\KiotaClientFactory;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
 
 class KiotaClientFactoryTest extends TestCase
 {
@@ -22,5 +28,42 @@ class KiotaClientFactoryTest extends TestCase
     public function testGetDefaultHandlerStack()
     {
         $this->assertInstanceOf(HandlerStack::class, KiotaClientFactory::getDefaultHandlerStack());
+    }
+
+    public function testMiddlewareProcessing()
+    {
+        $guzzleVersion = ClientInterface::MAJOR_VERSION;
+        $kiotaVersion = Constants::KIOTA_HTTP_CLIENT_VERSION;
+        $userAgentHeaderValue = "GuzzleHttp/$guzzleVersion kiota-php/$kiotaVersion";
+        $mockResponses = [
+            function (RequestInterface $request) use ($userAgentHeaderValue) {
+                // test parameter name decoding
+                $this->assertEquals('https://graph.microsoft.com/users?$top=5', (string) $request->getUri());
+                $this->assertTrue($request->hasHeader('User-Agent'));
+                $this->assertEquals($userAgentHeaderValue, $request->getHeaderLine('User-Agent'));
+                // trigger retry
+                return new Response(429, ['Retry-After' => '1']);
+            },
+            function (RequestInterface $retriedRequest) use ($userAgentHeaderValue) {
+                $this->assertEquals('https://graph.microsoft.com/users?$top=5', (string) $retriedRequest->getUri());
+                $this->assertTrue($retriedRequest->hasHeader('User-Agent'));
+                $this->assertEquals($userAgentHeaderValue, $retriedRequest->getHeaderLine('User-Agent'));
+                $this->assertTrue($retriedRequest->hasHeader('Retry-Attempt'));
+                $this->assertEquals('1', $retriedRequest->getHeaderLine('Retry-Attempt'));
+                // trigger redirect
+                return new Response(302, ['Location' => 'https://graph.microsoft.com/users?%24top=5']);
+            },
+            function (RequestInterface $request) use ($userAgentHeaderValue) {
+                // test no parameter name decoding. Redirect happens as is
+                $this->assertEquals('https://graph.microsoft.com/users?%24top=5', (string) $request->getUri());
+                $this->assertTrue($request->hasHeader('User-Agent'));
+                $this->assertEquals($userAgentHeaderValue, $request->getHeaderLine('User-Agent'));
+                return new Response(200);
+            }
+        ];
+        $middlewareStack = KiotaClientFactory::getDefaultHandlerStack();
+        $middlewareStack->setHandler(new MockHandler($mockResponses));
+        $mockClient = new Client(['handler' => $middlewareStack]);
+        $mockClient->get('https://graph.microsoft.com/users?%24top=5');
     }
 }

--- a/tests/Middleware/UserAgentHandlerTest.php
+++ b/tests/Middleware/UserAgentHandlerTest.php
@@ -3,6 +3,7 @@
 namespace Microsoft\Kiota\Http\Test\Middleware;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
@@ -50,7 +51,7 @@ class UserAgentHandlerTest extends TestCase
 
         $response = $this->executeMockRequest($mockResponse, $agentHandlerOption);
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertContains('kiota-php/0.1.0', $req->getHeader('User-Agent'));
+        $this->assertContains('GuzzleHttp/'.ClientInterface::MAJOR_VERSION.' kiota-php/0.1.0', $req->getHeader('User-Agent'));
     }
 
     private function executeMockRequest(


### PR DESCRIPTION
This PR:
- Reorders middleware stack:
    - Ensures no further request manipulation happens during a retry. Same exact request is retried.
    - Adds user agent header value to redirects
- When using the default user-agent configurator, appends kiota User-Agent value by space as opposed to the default comma based on examples in the [RFC](https://www.rfc-editor.org/rfc/rfc7231#section-5.5.3) & other [browser patterns](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent)
- Adds names to the middleware in the chain. The names can be referenced in the GraphClientFactory to replace default middleware with Graph specific middleware e.g. Replace default Retry Handler with Graph's retry handler.

part of https://github.com/microsoftgraph/msgraph-sdk-php-core/issues/108