### PR TITLE
Use Guzzle client lib directly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
 	"require": {
 		"php": "^7.4 | ^8.0",
-        "php-http/guzzle7-adapter": "^1.0",
+		"guzzlehttp/guzzle": "^7.0",
         "php-http/httplug": "^2.2",
 		"microsoft/kiota-abstractions": "^0.6.0",
 		"ext-zlib": "*",


### PR DESCRIPTION
We don't leverage any Guzzle 7 adapter's features. We can use the Guzzle client directly.