### PR TITLE
Bump min guzzle version to secure version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+### Changed
+
+## [1.2.0]
+
+### Changed
+- Bumped minimum required Guzzle HTTP version to secure version
+
 ## [1.1.0]
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "type": "library",
 	"require": {
 		"php": "^7.4 | ^8.0",
-		"guzzlehttp/guzzle": "^7.0",
-		"microsoft/kiota-abstractions": "^1.0.2",
+		"guzzlehttp/guzzle": "^7.4.5",
+		"microsoft/kiota-abstractions": "^1.1.0",
 		"ext-zlib": "*",
 		"ext-json": "*"
 	},

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -5,5 +5,5 @@ namespace Microsoft\Kiota\Http;
 final class Constants
 {
     /** @var string The current version for this Library */
-    public const KIOTA_HTTP_CLIENT_VERSION = '1.1.0';
+    public const KIOTA_HTTP_CLIENT_VERSION = '1.2.0';
 }


### PR DESCRIPTION
<7.4.5 has reported vulnerabilities. https://packagist.org/packages/guzzlehttp/guzzle