### PR TITLE
Fix segfault when running PHP 7.4 unit tests

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -16,25 +16,42 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['8.0', '8.1', '8.2']
+        php-versions: ['7.4', '8.1', '8.2', '8.3']
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
-      - name: Setup PHP and Xdebug for Code Coverage report
+      - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          coverage: xdebug
+          coverage: none
       - name: Install dependencies
         run: composer install
       - name: Run static analysis
         run: ./vendor/bin/phpstan
       - name: Run tests
+        run: ./vendor/bin/phpunit
+
+  code-coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup PHP and Xdebug for Code Coverage report
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.0'
+          coverage: xdebug
+      - name: Install dependencies
+        run: composer install
+      - name: Run static analysis
+        run: ./vendor/bin/phpstan
+      - name: Run tests with coverage
         run: ./vendor/bin/phpunit --coverage-clover=coverage.xml
       - name: Fix code coverage paths
         run: sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' coverage.xml
       - name: SonarCloud Scan
-        if: ${{ matrix.php-versions == '8.0' && !github.event.pull_request.head.repo.fork }}
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         uses: SonarSource/sonarcloud-github-action@master
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Segmentation fault is thrown when PHPUnit is run with code-coverage enabled using Xdebug & PHP 7.4.
Workaround in this PR is to run unit tests for PHP 7.4 without code-coverage and isolate our coverage checks to run with the PHP 8 unit tests