### PR TITLE
implemented workaround for some Graph API responses not returning Content-Type on success.

### DIFF
--- a/src/Exceptions/NoContentTypeHeaderException.php
+++ b/src/Exceptions/NoContentTypeHeaderException.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Microsoft\Kiota\Http\Exceptions;
+
+use Psr\Http\Message\ResponseInterface;
+use RuntimeException;
+use Throwable;
+
+class NoContentTypeHeaderException extends RuntimeException
+{
+
+    private ResponseInterface $_response;
+
+    public function __construct(string $message, ResponseInterface $response, int $code = 0, Throwable $previous = null)
+    {
+        $this->_response = $response;
+        parent::__construct($message, 0, $previous);
+    }
+
+    public function getResponse(): ResponseInterface
+    {
+        return $this->_response;
+    }
+
+}


### PR DESCRIPTION
This fix implements a workaround for certain responses from the Graph API (for example the Create Team call) where the API does not return the Content-Type header, even though documentation says it should return with said header.

A bug ticket has been raised to microsoft about this issue.

work around works by wrapping the RuntimeException used to indicate that the Content-Type header is missing with a custom NoContentTypeHeaderException and including the ResponseInterface $response in this wrapper exception.
This exception is backwards compatible with RuntimeException so existing catches of this exception will continue to work as they did before.