### PR TITLE
chore: Use main as default branch

### DIFF
--- a/.github/policies/kiota-http-guzzle-php-branch-protection.yml
+++ b/.github/policies/kiota-http-guzzle-php-branch-protection.yml
@@ -7,7 +7,7 @@ resource: repository
 configuration:
   branchProtectionRules:
 
-  - branchNamePattern: dev
+  - branchNamePattern: main
     # This branch pattern applies to the following branches as of 06/09/2023 14:08:44:
     # dev
 

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -3,9 +3,9 @@ name: Build
 on:
   workflow_dispatch:
   push:
-    branches: [ main, dev ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, dev ]
+    branches: [ main ]
 
 permissions:
   contents: read


### PR DESCRIPTION
`main` updated with latest changes: https://github.com/microsoft/kiota-http-guzzle-php/compare/main...dev